### PR TITLE
feat(image, user): 이미지 업로드 API 연동 & 마이페이지 프로필 수정 기능 구현

### DIFF
--- a/salgulok/src/api/image/confirmUpload.ts
+++ b/salgulok/src/api/image/confirmUpload.ts
@@ -1,0 +1,8 @@
+import api from "../api";
+import type { ImageConfirmRequest, ImageConfirmResponse } from "./types";
+
+/** 업로드 완료 확인 후 DB 반영 (POST /images/confirm) */
+export async function confirmUpload(body: ImageConfirmRequest) {
+    const { data } = await api.post<ImageConfirmResponse>("/images/confirm", body);
+    return data;
+}

--- a/salgulok/src/api/image/deleteImage.ts
+++ b/salgulok/src/api/image/deleteImage.ts
@@ -1,0 +1,6 @@
+import api from "../api";
+
+/** 단일 이미지 삭제 (DELETE /images/{imageId}) */
+export async function deleteImage(imageId: number) {
+    await api.delete(`/images/${imageId}`);
+}

--- a/salgulok/src/api/image/issueGetPresigned.ts
+++ b/salgulok/src/api/image/issueGetPresigned.ts
@@ -1,0 +1,10 @@
+import api from "../api";
+import type { PresignedUrlResponse } from "./types";
+
+/** 다운로드용 Presigned URL 발급 (GET /images/presigned?objectKey=...) */
+export async function issueGetPresigned(objectKey: string) {
+    const { data } = await api.get<PresignedUrlResponse>("/images/presigned", {
+        params: { objectKey },
+    });
+    return data;
+}

--- a/salgulok/src/api/image/issuePresigned.ts
+++ b/salgulok/src/api/image/issuePresigned.ts
@@ -1,0 +1,8 @@
+import api from "../api";
+import type { PresignedUrlRequest, PresignedUrlResponse } from "./types";
+
+/** 업로드용 Presigned URL 발급 (POST /images/presigned) */
+export async function issuePresigned(req: PresignedUrlRequest) {
+    const { data } = await api.post<PresignedUrlResponse>("/images/presigned", req);
+    return data;
+}

--- a/salgulok/src/api/image/types.ts
+++ b/salgulok/src/api/image/types.ts
@@ -1,0 +1,37 @@
+// 백엔드 DTO와 1:1 매칭
+
+export interface PresignedUrlRequest {
+    templateId?: number | null;
+    files: Array<{
+        fileName: string;
+        contentType: string;
+        size?: number;
+    }>;
+}
+
+export interface PresignedUrlItem {
+    fileName: string | null;
+    objectKey: string;
+    presignedUrl: string;
+    contentType: string;
+    expiresInSec: number;
+}
+
+export interface PresignedUrlResponse {
+    items: PresignedUrlItem[];
+}
+
+export interface ImageConfirmRequest {
+    //templateId?: number | null;
+    items: Array<{
+        objectKey: string;
+        url?: string;
+        fileName?: string;
+        contentType?: string;
+        size?: number;
+    }>;
+}
+
+export interface ImageConfirmResponse {
+    imageIds: number[];
+}

--- a/salgulok/src/api/image/uploadFlow.ts
+++ b/salgulok/src/api/image/uploadFlow.ts
@@ -1,0 +1,66 @@
+// src/api/image/uploadFlow.ts
+import { issuePresigned } from "./issuePresigned";
+import { confirmUpload } from "./confirmUpload";
+import { putToS3 } from "./uploadToS3";
+import type {
+    PresignedUrlRequest,
+    PresignedUrlItem,
+    ImageConfirmRequest,
+    ImageConfirmResponse,
+} from "./types";
+
+/** 파일 업로드 입력 타입 (Web) */
+export interface LocalFile {
+    file: File; //
+}
+
+/** 결과 타입은 동일 */
+export interface UploadFlowResult {
+    imageIds: number[];
+    items: PresignedUrlItem[];
+}
+
+/** 발급→업로드→확정 */
+export async function uploadImagesFlow(
+    files: LocalFile[],
+    options?: { templateId?: number | null }
+): Promise<UploadFlowResult> {
+    // 1) Presigned 발급 (File에서 메타 추출)
+    const presigned = await issuePresigned({
+        templateId: options?.templateId ?? null,
+        files: files.map(({ file }) => ({
+            fileName: file.name,
+            contentType: file.type,
+            size: file.size,
+        })),
+    } as PresignedUrlRequest);
+
+    if (presigned.items.length !== files.length) {
+        throw new Error("발급된 presigned 개수가 요청 파일 수와 다릅니다.");
+    }
+
+    // 2) S3 PUT (File 그대로 전송)
+    for (let i = 0; i < files.length; i++) {
+        const item = presigned.items[i];
+        const f = files[i].file;
+        await putToS3(item.presignedUrl, f, f.type);
+    }
+
+
+    // 3) confirm
+    const confirmBody: ImageConfirmRequest = {
+        //templateId: options?.templateId ?? null,
+        items: presigned.items.map((it, idx) => ({
+            objectKey: it.objectKey,
+            fileName: files[idx].file.name,
+            contentType: files[idx].file.type,
+            size: files[idx].file.size,
+        })),
+    };
+    const confirmed: ImageConfirmResponse = await confirmUpload(confirmBody);
+
+    return {
+        imageIds: confirmed.imageIds ?? [],
+        items: presigned.items,
+    };
+}

--- a/salgulok/src/api/image/uploadToS3.ts
+++ b/salgulok/src/api/image/uploadToS3.ts
@@ -1,0 +1,13 @@
+// src/api/image/uploadToS3.ts
+/** Web용 PUT: File/Blob을 그대로 업로드 */
+export async function putToS3(presignedUrl: string, file: File, contentType: string) {
+    const putRes = await fetch(presignedUrl, {
+        method: "PUT",
+        headers: { "Content-Type": contentType },
+        body: file,
+    });
+    if (!putRes.ok) {
+        const text = await putRes.text().catch(() => "");
+        throw new Error(`S3 업로드 실패: ${putRes.status} ${text}`);
+    }
+}

--- a/salgulok/src/api/user/updateProfileImage.ts
+++ b/salgulok/src/api/user/updateProfileImage.ts
@@ -1,0 +1,16 @@
+import api from "../api";
+
+export interface UpdateProfileImageRequest {
+    profileImg: string; // confirm 이후 받은 최종 URL
+}
+
+export async function updateProfileImage(body: UpdateProfileImageRequest) {
+    try {
+        const { data } = await api.put("/users/me", body);
+        // ⚠️ 여기는 백엔드 UserController 실제 엔드포인트에 맞게 수정해야 해
+        return data;
+    } catch (error) {
+        console.error("프로필 이미지 업데이트 실패", error);
+        throw error;
+    }
+}

--- a/salgulok/src/components/mypage/ProfileEdit.tsx
+++ b/salgulok/src/components/mypage/ProfileEdit.tsx
@@ -12,7 +12,7 @@ const EditProfileImage: React.FC<ProfileImageProps> = ({ imageUrl, onChange }) =
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleEditClick = () => {
-    fileInputRef.current?.click(); 
+    fileInputRef.current?.click();
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -64,3 +64,4 @@ const EditIcon = styled.img`
 const HiddenInput = styled.input`
   display: none;
 `;
+

--- a/salgulok/src/pages/mypage/EditProfilePage.tsx
+++ b/salgulok/src/pages/mypage/EditProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import EditProfile from "../../components/mypage/ProfileEdit";
@@ -7,23 +7,65 @@ import BottomButton from "../../components/common/BottomButton";
 import Header from "../../components/common/Header";
 import { nicknameDuplicate } from "../../api/user/nicknameDuplicate";
 import { updateUserProfile } from "../../api/user/editProfile";
-
-const dummy = { nickname: "제티", intro: "안뇽", profileImg: "" };
+import { issueGetPresigned } from "../../api/image/issueGetPresigned";   // POST /images/presigned
+import { getMyInfo } from "../../api/user/getMyProfile";
+import { uploadImagesFlow } from "../../api/image/uploadFlow";
 
 const EditProfilePage: React.FC = () => {
     const navigate = useNavigate();
 
-    const [username, setUsername] = useState(dummy.nickname);
-    const [intro, setIntro] = useState(dummy.intro);
-    const [profileImg, setProfileImg] = useState(dummy.profileImg);
+    const [username, setUsername] = useState("");
+    const [originalUsername, setOriginalUsername] = useState("");
+    const [intro, setIntro] = useState("");
+    const [profileImg, setProfileImg] = useState("");
+    const [profileImgObjectKey, setProfileImgObjectKey] = useState<string | null>(null);
 
     // 닉네임 중복 확인
-    const [isNicknameValid, setIsNicknameValid] = useState(false);  // 사용 가능한 닉네임인지
+    const [isNicknameValid, setIsNicknameValid] = useState(true);  // 사용 가능한 닉네임인지
+
+    useEffect(() => {
+        const fetchProfile = async () => {
+            try {
+                const data = await getMyInfo();
+                setUsername(data.nickname);
+                setOriginalUsername(data.nickname);
+                setIntro(data.intro || "");
+                if (data.profileImg) {
+                    try {
+                        const presignedData = await issueGetPresigned(data.profileImg);
+                        if (presignedData.items.length > 0) {
+                            setProfileImg(presignedData.items[0].presignedUrl);
+                        }
+                    } catch (e) {
+                        setProfileImg(data.profileImg);
+                    }
+                }
+            } catch (error) {
+                console.error("Failed to fetch profile", error);
+            }
+        };
+        fetchProfile();
+    }, []);
+
+    useEffect(() => {
+        if (username === originalUsername) {
+            setIsNicknameValid(true);
+        } else {
+            setIsNicknameValid(false);
+        }
+    }, [username, originalUsername]);
+
 
     const handleCheck = async () => {
         if (!username.trim()) {
         alert("닉네임을 입력해주세요.");
         return;
+        }
+
+        if (username === originalUsername) {
+            alert("현재 닉네임과 동일합니다.");
+            setIsNicknameValid(true);
+            return;
         }
 
         try {
@@ -50,24 +92,65 @@ const EditProfilePage: React.FC = () => {
         }
 
         try {
-          await updateUserProfile({
+          const profileData: {
+            username: string;
+            intro: string | null;
+            profileImg?: string | null;
+          } = {
             username,
             intro: intro.trim() === "" ? null : intro,
-            profileImg: profileImg,
-          });
+          };
+
+          if (profileImgObjectKey) {
+            profileData.profileImg = profileImgObjectKey;
+          }
+
+          await updateUserProfile(profileData);
     
           alert("회원정보 변경이 완료되었습니다.");
-          navigate("/");
+          navigate("/mypage");
         } catch (error) {
           console.error("회원정보 변경 실패", error);
         }
     }
 
-    const handleImageChange = (file: File) => {
-        // TODO: 서버 업로드 로직 추가 후 해당 이미지로 변경
-        setProfileImg("");
+    // const handleImageChange = (file: File) => {
+    //     // TODO: 서버 업로드 로직 추가 후 해당 이미지로 변경
+    //     setProfileImg("");
+    // };
+    //
+    const handleImageChange = async (file: File) => {
+        // presigned → S3 PUT → confirm 은 그대로 수행
+        // confirm 응답에서 최종 URL 추출
+        // const finalUrl = confirmRes.items[0].url;
+
+        // 여기서 바로 API 호출
+        // await updateProfileImage({ profileImg: finalUrl });
+
+        // 상태에도 반영해서 미리보기 업데이트
+        // setProfileImg(finalUrl);
+
+        if (!file) return;
+
+        try {
+            const uploadResult = await uploadImagesFlow([{ file }]);
+            if (uploadResult.items.length === 0) {
+                throw new Error("Image upload failed.");
+            }
+            const newObjectKey = uploadResult.items[0].objectKey;
+            setProfileImgObjectKey(newObjectKey);
+
+            const presignedData = await issueGetPresigned(newObjectKey);
+            if (presignedData.items.length === 0) {
+                throw new Error("Failed to get presigned URL for preview.");
+            }
+            const previewUrl = presignedData.items[0].presignedUrl;
+            setProfileImg(previewUrl);
+        } catch (error) {
+            console.error("Error during image change:", error);
+            alert("이미지 변경 중 오류가 발생했습니다.");
+        }
     };
-  
     return (    
         <Container>
             <Header title="마이페이지" showBackButton/>


### PR DESCRIPTION
- ImageController 백엔드 API 프론트엔드 연결
- 프로필 이미지 업로드(S3 Presigned → Confirm) 플로우 적용
- 마이페이지 닉네임/자기소개/프로필 이미지 수정 가능

## 🍑 작업 개요
- 구현한 기능을 요약하여 정리합니다.

## 🚧 구현 중 겪은 이슈 및 해결 방법


## 🔍 참고 사항


## 🖼️ 스크린샷 (선택)
> UI 변경이 있을 경우 첨부해 주세요  
- Before | After 비교 이미지 등


## 🔗 관련 이슈
- (ex) closes #이슈번호
